### PR TITLE
Add generic interface for recording backend metrics

### DIFF
--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestFilterBeanPostProcessor.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestFilterBeanPostProcessor.java
@@ -27,12 +27,12 @@ import org.springframework.web.client.RestTemplate;
 public class ZmonRestFilterBeanPostProcessor implements BeanPostProcessor {
     private static final Log logger = LogFactory.getLog(ZmonRestFilterBeanPostProcessor.class);
 
-    private final ZmonRestResponseBackendMetricsFilter zmonRestResponseFilter;
+    private final ZmonRestResponseBackendMetricsInterceptor interceptor;
 
     @Autowired
     public ZmonRestFilterBeanPostProcessor(
-            final ZmonRestResponseBackendMetricsFilter zmonRestResponseBackendMetricsFilter) {
-        this.zmonRestResponseFilter = zmonRestResponseBackendMetricsFilter;
+            final ZmonRestResponseBackendMetricsInterceptor zmonRestResponseBackendMetricsFilter) {
+        this.interceptor = zmonRestResponseBackendMetricsFilter;
     }
 
     @Override
@@ -43,7 +43,7 @@ public class ZmonRestFilterBeanPostProcessor implements BeanPostProcessor {
 
             RestTemplate restTemplateBean = (RestTemplate) possiblyRestTemplateBean;
 
-            restTemplateBean.getInterceptors().add(zmonRestResponseFilter);
+            restTemplateBean.getInterceptors().add(interceptor);
             logger.info("Added " + ZmonRestFilterBeanPostProcessor.class.getCanonicalName() + " instance to "
                     + beanName);
         }

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptor.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptor.java
@@ -31,12 +31,12 @@ import org.zalando.zmon.actuator.metrics.MetricsWrapper;
 import com.google.common.base.Stopwatch;
 
 @Component
-public class ZmonRestResponseBackendMetricsFilter implements ClientHttpRequestInterceptor {
+public class ZmonRestResponseBackendMetricsInterceptor implements ClientHttpRequestInterceptor {
 
     private final MetricsWrapper metricsWrapper;
 
     @Autowired
-    public ZmonRestResponseBackendMetricsFilter(final MetricsWrapper metricsWrapper) {
+    public ZmonRestResponseBackendMetricsInterceptor(final MetricsWrapper metricsWrapper) {
         this.metricsWrapper = metricsWrapper;
     }
 

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/metrics/MetricsWrapper.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/metrics/MetricsWrapper.java
@@ -15,28 +15,20 @@
  */
 package org.zalando.zmon.actuator.metrics;
 
-import java.io.IOException;
-
-import java.util.concurrent.TimeUnit;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-import org.springframework.beans.factory.annotation.Autowired;
-
-import org.springframework.http.HttpRequest;
-import org.springframework.http.client.ClientHttpResponse;
-
-import org.springframework.stereotype.Component;
-
-import org.springframework.web.servlet.HandlerMapping;
-
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-
 import com.google.common.base.Stopwatch;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 @Component
 public class MetricsWrapper {
@@ -57,14 +49,17 @@ public class MetricsWrapper {
         submitToTimer(getKey("zmon.response." + status + "." + request.getMethod().toUpperCase() + suffix), time);
     }
 
+    public void recordBackendRoundTripMetrics(final String requestMethod, final String host, final int status,
+            final long time) {
+
+        submitToTimer(getKey(String.format("zmon.request.%s.%s.%s", status, requestMethod.toUpperCase(), host)), time);
+    }
+
     public void recordBackendRoundTripMetrics(final HttpRequest request, final ClientHttpResponse response,
             final Stopwatch stopwatch) {
 
         try {
-            submitToTimer(getKey(
-                    String.format("zmon.request.%s.%s.%s", response.getStatusCode().toString(),
-                        request.getMethod().name().toUpperCase(), getHost(request))),
-                stopwatch.elapsed(TimeUnit.MILLISECONDS));
+            recordBackendRoundTripMetrics(request.getMethod().name(), getHost(request), response.getRawStatusCode(), stopwatch.elapsed(TimeUnit.MILLISECONDS));
         } catch (IOException e) {
             logger.warn("Could not detect status for " + response);
         }

--- a/zmon-actuator/src/test/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptorTest.java
+++ b/zmon-actuator/src/test/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptorTest.java
@@ -39,7 +39,7 @@ import org.zalando.zmon.actuator.metrics.MetricsWrapper;
 
 import com.google.common.base.Stopwatch;
 
-public class ZmonRestResponseBackendMetricsFilterTest {
+public class ZmonRestResponseBackendMetricsInterceptorTest {
 
     public static final int PREFERRED_SLEEP_TIME = 200;
     MetricsWrapper mockedWrapper = Mockito.mock(MetricsWrapper.class);
@@ -47,7 +47,7 @@ public class ZmonRestResponseBackendMetricsFilterTest {
 
     @Test
     public void testTimeElapsing() throws IOException {
-        ZmonRestResponseBackendMetricsFilter zmonRestResponseFilter = new ZmonRestResponseBackendMetricsFilter(
+        ZmonRestResponseBackendMetricsInterceptor interceptor = new ZmonRestResponseBackendMetricsInterceptor(
                 mockedWrapper);
 
         Mockito.when(execution.execute(Mockito.any(HttpRequest.class), Mockito.any(byte[].class))).then(
@@ -60,7 +60,7 @@ public class ZmonRestResponseBackendMetricsFilterTest {
             });
 
         ArgumentCaptor<Stopwatch> stopwatchArgumentCaptor = ArgumentCaptor.forClass(Stopwatch.class);
-        zmonRestResponseFilter.intercept(null, null, execution);
+        interceptor.intercept(null, null, execution);
 
         Mockito.verify(mockedWrapper, times(1)).recordBackendRoundTripMetrics(Mockito.any(HttpRequest.class),
             Mockito.any(ClientHttpResponse.class), stopwatchArgumentCaptor.capture());


### PR DESCRIPTION
- added a generic interface for recording backend metrics in `MetricsWrapper` to be used in situations without `RestTemplate`. As the old logic is now forwarding no tests were adapted.
- renamed `ZmonRestResponseBackendMetricsFilter` to `ZmonRestResponseBackendMetricsInterceptor`
