### PR TITLE
Clean up AutoConfiguration

### DIFF
--- a/zmon-actuator/pom.xml
+++ b/zmon-actuator/pom.xml
@@ -17,6 +17,11 @@
 			<artifactId>spring-webmvc</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<version>1.3.1.RELEASE</version>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<optional>true</optional>

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptor.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptor.java
@@ -15,27 +15,19 @@
  */
 package org.zalando.zmon.actuator;
 
-import java.io.IOException;
-
-import org.springframework.beans.factory.annotation.Autowired;
-
+import com.google.common.base.Stopwatch;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-
-import org.springframework.stereotype.Component;
-
 import org.zalando.zmon.actuator.metrics.MetricsWrapper;
 
-import com.google.common.base.Stopwatch;
+import java.io.IOException;
 
-@Component
 public class ZmonRestResponseBackendMetricsInterceptor implements ClientHttpRequestInterceptor {
 
     private final MetricsWrapper metricsWrapper;
 
-    @Autowired
     public ZmonRestResponseBackendMetricsInterceptor(final MetricsWrapper metricsWrapper) {
         this.metricsWrapper = metricsWrapper;
     }

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/config/ZmonMetricsAutoConfiguration.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/config/ZmonMetricsAutoConfiguration.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.zmon.actuator.config;
+
+import com.codahale.metrics.MetricRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.zalando.zmon.actuator.ZmonMetricsFilter;
+import org.zalando.zmon.actuator.ZmonRestResponseBackendMetricsInterceptor;
+import org.zalando.zmon.actuator.metrics.MetricsWrapper;
+
+/**
+ * @author jbellmann
+ */
+
+@Configuration
+@ConditionalOnClass(MetricRegistry.class)
+@AutoConfigureAfter(name = "MetricsDropwizardAutoConfiguration")
+public class ZmonMetricsAutoConfiguration {
+
+    @Bean(name = "zmonMetricsWrapper")
+    public MetricsWrapper zmonMetricsWrapper(final MetricRegistry metricRegistry) {
+        return new MetricsWrapper(metricRegistry);
+    }
+
+    @Bean
+    public ZmonMetricsFilter zmonMetricsFilter(final MetricsWrapper metricsWrapper) {
+        return new ZmonMetricsFilter(metricsWrapper);
+    }
+
+    @Bean
+    public ZmonRestResponseBackendMetricsInterceptor zmonRestResponseBackendMetricsInterceptor(
+            final MetricsWrapper metricsWrapper) {
+        return new ZmonRestResponseBackendMetricsInterceptor(metricsWrapper);
+    }
+
+}

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/config/ZmonPostProcessorAutoConfiguration.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/config/ZmonPostProcessorAutoConfiguration.java
@@ -15,35 +15,25 @@
  */
 package org.zalando.zmon.actuator.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.zalando.zmon.actuator.ZmonMetricsFilter;
-import org.zalando.zmon.actuator.metrics.MetricsWrapper;
-
 import com.codahale.metrics.MetricRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.zalando.zmon.actuator.ZmonRestFilterBeanPostProcessor;
 
 /**
- * @author  jbellmann
+ * @author jbellmann
  */
 @Configuration
-@ComponentScan("org.zalando.zmon.actuator")
-public class ZmonMetricFilterAutoConfiguration {
-
-
-    @Autowired
-    private MetricRegistry metricRegistry;
-
+@ConditionalOnClass(MetricRegistry.class)
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
+public class ZmonPostProcessorAutoConfiguration {
 
     @Bean
-    public ZmonMetricsFilter zmonMetricsFilter() {
-        return new ZmonMetricsFilter(metricsWrapper());
-    }
-
-    @Bean
-    public MetricsWrapper metricsWrapper() {
-        return new MetricsWrapper(metricRegistry);
+    public static ZmonRestFilterBeanPostProcessor zmonRestFilterBeanPostProcessor() {
+        return new ZmonRestFilterBeanPostProcessor();
     }
 
 }

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/metrics/MetricsWrapper.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/metrics/MetricsWrapper.java
@@ -23,14 +23,12 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-@Component
 public class MetricsWrapper {
 
     private static final String UNKNOWN_PATH_SUFFIX = "/unmapped";

--- a/zmon-actuator/src/main/resources/META-INF/spring.factories
+++ b/zmon-actuator/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 #
 #
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.zalando.zmon.actuator.config.ZmonMetricFilterAutoConfiguration
+org.zalando.zmon.actuator.config.ZmonPostProcessorAutoConfiguration,\
+org.zalando.zmon.actuator.config.ZmonMetricsAutoConfiguration

--- a/zmon-actuator/src/test/java/org/zalando/zmon/actuator/ExampleApplication.java
+++ b/zmon-actuator/src/test/java/org/zalando/zmon/actuator/ExampleApplication.java
@@ -19,7 +19,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
- * @author  jbellmann
+ * @author jbellmann
  */
 @SpringBootApplication
 public class ExampleApplication {


### PR DESCRIPTION
The `AutoConfiguration` has been split up to isolate the `BeanPostProcessor`. Additionally no more autowiring is being used inside it, both to prevent bean lifecycle problems as described [here](https://jira.spring.io/browse/SPR-12559) and [here](http://stackoverflow.com/questions/1201726/tracking-down-cause-of-springs-not-eligible-for-auto-proxying).
