### PR TITLE
Remove google-guava dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot.version>1.3.1.RELEASE</spring-boot.version>
+        <spring-boot.version>1.3.6.RELEASE</spring-boot.version>
 
         <coveralls.dryRun>true</coveralls.dryRun>
         <main.basedir>${basedir}</main.basedir>
@@ -50,7 +50,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.4.201502262128</version>
+                    <version>0.7.7.201606060606</version>
                     <executions>
                         <execution>
                             <id>default-prepare-agent</id>

--- a/zmon-actuator/pom.xml
+++ b/zmon-actuator/pom.xml
@@ -17,6 +17,11 @@
 			<artifactId>spring-webmvc</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure</artifactId>
+			<version>1.3.1.RELEASE</version>
+		</dependency>
+		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<optional>true</optional>

--- a/zmon-actuator/pom.xml
+++ b/zmon-actuator/pom.xml
@@ -19,20 +19,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-autoconfigure</artifactId>
-			<version>1.3.1.RELEASE</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<optional>true</optional>
 		</dependency>
-
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-			<version>18.0</version>
-		</dependency>
-
 
 		<!-- TESTING -->
 		<dependency>

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptor.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptor.java
@@ -15,14 +15,14 @@
  */
 package org.zalando.zmon.actuator;
 
-import com.google.common.base.Stopwatch;
+import java.io.IOException;
+
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StopWatch;
 import org.zalando.zmon.actuator.metrics.MetricsWrapper;
-
-import java.io.IOException;
 
 public class ZmonRestResponseBackendMetricsInterceptor implements ClientHttpRequestInterceptor {
 
@@ -36,7 +36,8 @@ public class ZmonRestResponseBackendMetricsInterceptor implements ClientHttpRequ
     public ClientHttpResponse intercept(final HttpRequest request, final byte[] body,
             final ClientHttpRequestExecution execution) throws IOException {
 
-        Stopwatch stopwatch = Stopwatch.createStarted();
+        StopWatch stopwatch = new StopWatch();
+        stopwatch.start();
         ClientHttpResponse response = execution.execute(request, body);
         stopwatch.stop();
         metricsWrapper.recordBackendRoundTripMetrics(request, response, stopwatch);

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptor.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptor.java
@@ -15,27 +15,19 @@
  */
 package org.zalando.zmon.actuator;
 
-import java.io.IOException;
-
-import org.springframework.beans.factory.annotation.Autowired;
-
+import com.google.common.base.Stopwatch;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-
-import org.springframework.stereotype.Component;
-
 import org.zalando.zmon.actuator.metrics.MetricsWrapper;
 
-import com.google.common.base.Stopwatch;
+import java.io.IOException;
 
-@Component
 public class ZmonRestResponseBackendMetricsInterceptor implements ClientHttpRequestInterceptor {
 
     private final MetricsWrapper metricsWrapper;
 
-    @Autowired
     public ZmonRestResponseBackendMetricsInterceptor(final MetricsWrapper metricsWrapper) {
         this.metricsWrapper = metricsWrapper;
     }

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/config/ZmonMetricsAutoConfiguration.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/config/ZmonMetricsAutoConfiguration.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 Zalando SE (http://tech.zalando.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zalando.zmon.actuator.config;
+
+import com.codahale.metrics.MetricRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.zalando.zmon.actuator.ZmonMetricsFilter;
+import org.zalando.zmon.actuator.ZmonRestResponseBackendMetricsInterceptor;
+import org.zalando.zmon.actuator.metrics.MetricsWrapper;
+
+/**
+ * @author jbellmann
+ */
+
+@Configuration
+@ConditionalOnClass(MetricRegistry.class)
+@AutoConfigureAfter(name = "MetricsDropwizardAutoConfiguration")
+public class ZmonMetricsAutoConfiguration {
+
+    @Bean(name = "zmonMetricsWrapper")
+    public MetricsWrapper zmonMetricsWrapper(final MetricRegistry metricRegistry) {
+        return new MetricsWrapper(metricRegistry);
+    }
+
+    @Bean
+    public ZmonMetricsFilter zmonMetricsFilter(final MetricsWrapper metricsWrapper) {
+        return new ZmonMetricsFilter(metricsWrapper);
+    }
+
+    @Bean
+    public ZmonRestResponseBackendMetricsInterceptor zmonRestResponseBackendMetricsInterceptor(
+            final MetricsWrapper metricsWrapper) {
+        return new ZmonRestResponseBackendMetricsInterceptor(metricsWrapper);
+    }
+
+}

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/config/ZmonPostProcessorAutoConfiguration.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/config/ZmonPostProcessorAutoConfiguration.java
@@ -15,35 +15,25 @@
  */
 package org.zalando.zmon.actuator.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.zalando.zmon.actuator.ZmonMetricsFilter;
-import org.zalando.zmon.actuator.metrics.MetricsWrapper;
-
 import com.codahale.metrics.MetricRegistry;
+import org.springframework.boot.autoconfigure.AutoConfigureOrder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.zalando.zmon.actuator.ZmonRestFilterBeanPostProcessor;
 
 /**
- * @author  jbellmann
+ * @author jbellmann
  */
 @Configuration
-@ComponentScan("org.zalando.zmon.actuator")
-public class ZmonMetricFilterAutoConfiguration {
-
-
-    @Autowired
-    private MetricRegistry metricRegistry;
-
+@ConditionalOnClass(MetricRegistry.class)
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
+public class ZmonPostProcessorAutoConfiguration {
 
     @Bean
-    public ZmonMetricsFilter zmonMetricsFilter() {
-        return new ZmonMetricsFilter(metricsWrapper());
-    }
-
-    @Bean
-    public MetricsWrapper metricsWrapper() {
-        return new MetricsWrapper(metricRegistry);
+    public static ZmonRestFilterBeanPostProcessor zmonRestFilterBeanPostProcessor() {
+        return new ZmonRestFilterBeanPostProcessor();
     }
 
 }

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/metrics/MetricsWrapper.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/metrics/MetricsWrapper.java
@@ -23,14 +23,12 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-@Component
 public class MetricsWrapper {
 
     private static final String UNKNOWN_PATH_SUFFIX = "/unmapped";

--- a/zmon-actuator/src/main/java/org/zalando/zmon/actuator/metrics/MetricsWrapper.java
+++ b/zmon-actuator/src/main/java/org/zalando/zmon/actuator/metrics/MetricsWrapper.java
@@ -15,19 +15,21 @@
  */
 package org.zalando.zmon.actuator.metrics;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Timer;
-import com.google.common.base.Stopwatch;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.StopWatch;
 import org.springframework.web.servlet.HandlerMapping;
 
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 
 public class MetricsWrapper {
 
@@ -54,10 +56,10 @@ public class MetricsWrapper {
     }
 
     public void recordBackendRoundTripMetrics(final HttpRequest request, final ClientHttpResponse response,
-            final Stopwatch stopwatch) {
+            final StopWatch stopwatch) {
 
         try {
-            recordBackendRoundTripMetrics(request.getMethod().name(), getHost(request), response.getRawStatusCode(), stopwatch.elapsed(TimeUnit.MILLISECONDS));
+            recordBackendRoundTripMetrics(request.getMethod().name(), getHost(request), response.getRawStatusCode(), stopwatch.getTotalTimeMillis());
         } catch (IOException e) {
             logger.warn("Could not detect status for " + response);
         }

--- a/zmon-actuator/src/main/resources/META-INF/spring.factories
+++ b/zmon-actuator/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 #
 #
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.zalando.zmon.actuator.config.ZmonMetricFilterAutoConfiguration
+org.zalando.zmon.actuator.config.ZmonPostProcessorAutoConfiguration,\
+org.zalando.zmon.actuator.config.ZmonMetricsAutoConfiguration

--- a/zmon-actuator/src/test/java/org/zalando/zmon/actuator/ExampleApplication.java
+++ b/zmon-actuator/src/test/java/org/zalando/zmon/actuator/ExampleApplication.java
@@ -19,7 +19,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 /**
- * @author  jbellmann
+ * @author jbellmann
  */
 @SpringBootApplication
 public class ExampleApplication {

--- a/zmon-actuator/src/test/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptorTest.java
+++ b/zmon-actuator/src/test/java/org/zalando/zmon/actuator/ZmonRestResponseBackendMetricsInterceptorTest.java
@@ -19,25 +19,17 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import java.io.IOException;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Assert;
 import org.junit.Test;
-
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-
 import org.mockito.invocation.InvocationOnMock;
-
 import org.mockito.stubbing.Answer;
-
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpResponse;
-
+import org.springframework.util.StopWatch;
 import org.zalando.zmon.actuator.metrics.MetricsWrapper;
-
-import com.google.common.base.Stopwatch;
 
 public class ZmonRestResponseBackendMetricsInterceptorTest {
 
@@ -59,7 +51,7 @@ public class ZmonRestResponseBackendMetricsInterceptorTest {
                 }
             });
 
-        ArgumentCaptor<Stopwatch> stopwatchArgumentCaptor = ArgumentCaptor.forClass(Stopwatch.class);
+        ArgumentCaptor<StopWatch> stopwatchArgumentCaptor = ArgumentCaptor.forClass(StopWatch.class);
         interceptor.intercept(null, null, execution);
 
         Mockito.verify(mockedWrapper, times(1)).recordBackendRoundTripMetrics(Mockito.any(HttpRequest.class),
@@ -69,7 +61,7 @@ public class ZmonRestResponseBackendMetricsInterceptorTest {
 
     }
 
-    private boolean takesAtLeastSleepTime(final ArgumentCaptor<Stopwatch> stopwatchArgumentCaptor) {
-        return stopwatchArgumentCaptor.getValue().elapsed(TimeUnit.MILLISECONDS) >= PREFERRED_SLEEP_TIME;
+    private boolean takesAtLeastSleepTime(final ArgumentCaptor<StopWatch> stopwatchArgumentCaptor) {
+        return stopwatchArgumentCaptor.getValue().getTotalTimeMillis() >= PREFERRED_SLEEP_TIME;
     }
 }


### PR DESCRIPTION
This PR superseded #11. It's all fine there but it's possible to remove the dependency on google-guava and use Springs own 'StopWatch'-Implementation.
